### PR TITLE
Fix annotation offsets in message formatter

### DIFF
--- a/app/src/main/java/com/druk/lmplayground/conversation/MessageFormatter.kt
+++ b/app/src/main/java/com/druk/lmplayground/conversation/MessageFormatter.kt
@@ -66,10 +66,13 @@ fun messageFormatter(
                 primary = primary,
                 codeSnippetBackground = codeSnippetBackground
             )
+
+            val start = length
             append(annotatedString)
+            val end = length
 
             if (stringAnnotation != null) {
-                val (item, start, end, tag) = stringAnnotation
+                val (item, _s, _e, tag) = stringAnnotation
                 addStringAnnotation(tag = tag, start = start, end = end, annotation = item)
             }
 


### PR DESCRIPTION
## Summary
- ensure `messageFormatter` creates correct annotation ranges when formatting text

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687878c81a488330b2cf935ec52351f8