### PR TITLE
Add Conversation send message test

### DIFF
--- a/app/src/androidTest/java/com/druk/lmplayground/ConversationTest.kt
+++ b/app/src/androidTest/java/com/druk/lmplayground/ConversationTest.kt
@@ -3,6 +3,10 @@ package com.druk.lmplayground
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import com.druk.lmplayground.conversation.ConversationBarTestTag
 import org.junit.Rule
 import org.junit.Test
@@ -16,5 +20,14 @@ class ConversationTest {
     fun testAppLaunch() {
         // Check that the conversation screen is visible on launch
         composeTestRule.onNodeWithTag(ConversationBarTestTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testSendMessage() {
+        val message = "Hello"
+        composeTestRule.onNodeWithContentDescription("Text input")
+            .performTextInput(message)
+        composeTestRule.onNodeWithText("Send").performClick()
+        composeTestRule.onNodeWithText(message).assertIsDisplayed()
     }
 }


### PR DESCRIPTION
## Summary
- extend ConversationTest to validate sending a message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787aa1eec48330abd4c696e2212de6