### PR TITLE
Remove upstream owner references

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ LM Playground is designed as a universal platform for experimenting with various
 * Google Gemma2 9B
 
 ## Install
-If you're just looking to install LM Playground, you can find it on [Google Play](https://play.google.com/store/apps/details?id=com.druk.lmplayground). If you're a developer wanting to contribute, read on.
+If you're just looking to install LM Playground, you can find it on Google Play. If you're a developer wanting to contribute, read on.
 
 ## Build Instructions
 Prerequisites:
@@ -30,7 +30,7 @@ Prerequisites:
 
 1. Clone the repository:
 ```
-git clone https://github.com/andriydruk/LMPlayground.git
+git clone https://github.com/gkrost/LMPlayground.git
 ```
 2. Open the project in Android Studio: `File` > `Open` > Select the cloned repository.
 3. Connect an Android device or start an emulator.
@@ -43,6 +43,6 @@ This project is licensed under the [MIT License](LICENSE).
 This project was built based on [llama.cpp](https://github.com/ggerganov/llama.cpp) project. The application uses GGUF-format models with Q4KM quantization from [Hugging Face](https://huggingface.co/).
 
 # Contact
-If you have any questions, suggestions, or issues, feel free to open an issue or contact me directly at [me@andriydruk.com](mailto:me@andriydruk.com).
+If you have any questions, suggestions, or issues, feel free to open an issue.
 
 

--- a/app/src/main/cpp/LlamaCpp.h
+++ b/app/src/main/cpp/LlamaCpp.h
@@ -1,5 +1,5 @@
 //
-// Created by Andrew Druk on 22.01.2024.
+// Part of the LMPlayground project
 //
 
 #ifndef LMPLAYGROUND_LLAMACPP_H

--- a/app/src/main/cpp/LlamaGenerationSession.cpp
+++ b/app/src/main/cpp/LlamaGenerationSession.cpp
@@ -1,5 +1,5 @@
 //
-// Created by Andrew Druk on 22.01.2024.
+// Part of the LMPlayground project
 //
 
 #include <jni.h>

--- a/app/src/main/cpp/LlamaModel.cpp
+++ b/app/src/main/cpp/LlamaModel.cpp
@@ -1,5 +1,5 @@
 //
-// Created by Andrew Druk on 24.01.2024.
+// Part of the LMPlayground project
 //
 
 #include <jni.h>


### PR DESCRIPTION
## Summary
- update repo clone URL in README
- remove link and contact info referencing upstream owner
- remove original author comments in JNI sources

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878856865348330aaf8b0d34c85053b