### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -2,6 +2,9 @@ name: Pull Request Check
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
 
   AndroidTest:


### PR DESCRIPTION
Potential fix for [https://github.com/gkrost/LMPlayground/security/code-scanning/1](https://github.com/gkrost/LMPlayground/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, such as checking out the repository and running tests, the `contents: read` permission is sufficient. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
